### PR TITLE
[#7]-조회 성능 이슈

### DIFF
--- a/src/main/java/jpa/jpa_shop/domain/orders/Order.java
+++ b/src/main/java/jpa/jpa_shop/domain/orders/Order.java
@@ -4,6 +4,7 @@ import jpa.jpa_shop.domain.MiddleTable.OrderItem;
 import jpa.jpa_shop.domain.delivery.Delivery;
 import jpa.jpa_shop.domain.delivery.DeliveryStatus;
 import jpa.jpa_shop.domain.member.Member;
+import jpa.jpa_shop.web.controller.dto.response.order.OrderResponseDto;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,7 +46,7 @@ public class Order {
     private Delivery delivery;
 
     @Builder
-    public Order(LocalDateTime orderDate, OrderStatus status, Member member, Delivery delivery) {
+    private Order(LocalDateTime orderDate, OrderStatus status, Member member, Delivery delivery) {
         this.orderDate = orderDate;
         this.status = status;
         this.member = member;
@@ -94,5 +95,18 @@ public class Order {
     public String LocalDateTimeFormat()
     {
         return this.orderDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+    }
+
+    public OrderResponseDto toDto()
+    {
+        return OrderResponseDto.builder()
+                .id(this.id)
+                .itemRepresentation(orderItems.get(0).getItem().getName())
+                .totalPrice(this.getTotalPrice())
+                .orderStatus(this.status)
+                .memberName(this.getMember().getName())
+                .address(this.delivery.getAddress())
+                .orderDate(this.orderDate)
+                .build();
     }
 }

--- a/src/main/java/jpa/jpa_shop/domain/orders/Repository/OrderRepository.java
+++ b/src/main/java/jpa/jpa_shop/domain/orders/Repository/OrderRepository.java
@@ -31,6 +31,7 @@ public class OrderRepository {
     }
     // JPQL
     public List<Order> findAllJPQL(OrderSearchRequestDto orderSearch)
+
     {
         String jpql = "select o From Order o join o.member m";
         boolean isFirstCondition = true;
@@ -66,6 +67,7 @@ public class OrderRepository {
         }
         return query.getResultList();
     }
+    // queryDsl
     public List<Order> findAll(OrderSearchRequestDto orderSearch)
     {
         QOrder order=QOrder.order;
@@ -81,6 +83,7 @@ public class OrderRepository {
                 .limit(1000)
                 .fetch();
     }
+
     private BooleanExpression statusEquals(OrderStatus orderStatus)
     {
         if(orderStatus==null)
@@ -97,4 +100,11 @@ public class OrderRepository {
         return QMember.member.name.like(memberName);
     }
 
+
+    public List<Order> findWithMemberAndDelivery()
+    {
+        return em.createQuery("select o from Order o " +
+                "join fetch o.member m " +
+                "join fetch o.delivery d",Order.class).getResultList();
+    }
 }

--- a/src/main/java/jpa/jpa_shop/initDB.java
+++ b/src/main/java/jpa/jpa_shop/initDB.java
@@ -1,0 +1,108 @@
+package jpa.jpa_shop;
+
+import jpa.jpa_shop.domain.MiddleTable.OrderItem;
+import jpa.jpa_shop.domain.delivery.Delivery;
+import jpa.jpa_shop.domain.delivery.DeliveryStatus;
+import jpa.jpa_shop.domain.item.Album;
+import jpa.jpa_shop.domain.item.Book;
+import jpa.jpa_shop.domain.item.Movie;
+import jpa.jpa_shop.domain.member.Address;
+import jpa.jpa_shop.domain.member.Member;
+import jpa.jpa_shop.domain.orders.Order;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.annotation.PostConstruct;
+import javax.persistence.EntityManager;
+
+@Component
+@RequiredArgsConstructor
+public class initDB {
+    private final InitService initService;
+
+    @PostConstruct
+    public void init() {
+        initService.dbInit();
+        initService.dbInit2();
+    }
+    @Component
+    @Transactional
+    @RequiredArgsConstructor
+    static class InitService{
+        private final EntityManager em;
+        public void dbInit()
+        {
+            Member member = Member.builder().
+                    name("PARK").
+                    address(Address.builder().city("Seoul").street("soso street").zipcode("59-1").build())
+                    .build();
+
+
+            em.persist(member);
+
+            Movie movie = Movie.builder()
+                    .actor("송강호")
+                    .director("봉준호")
+                    .name("괴물")
+                    .price(10000)
+                    .stockQuantity(10)
+                    .build();
+
+            Book book = Book.builder()
+                    .author("구종만")
+                    .isbn("isbn")
+                    .name("알고리즘 문제 해결 전략")
+                    .price(33000)
+                    .stockQuantity(10)
+                    .build();
+
+            em.persist(movie);
+            em.persist(book);
+
+            OrderItem orderItem = OrderItem.createOrderItem(book, book.getPrice(), 2);
+            OrderItem orderItem2 = OrderItem.createOrderItem(movie, movie.getPrice(), 1);
+            Order order = Order.createOrder(member,
+                    Delivery.builder().address(member.getAddress()).status(DeliveryStatus.READY).build()
+                    , orderItem, orderItem2);
+            em.persist(order);
+        }
+
+        public void dbInit2()
+        {
+            Member member = Member.builder().
+                    name("PARK").
+                    address(Address.builder().city("Seoul").street("gogo street").zipcode("11-1").build())
+                    .build();
+
+            em.persist(member);
+
+            Album album = Album.builder()
+                    .artist("IU")
+                    .name("밤 편지")
+                    .price(55000)
+                    .stockQuantity(10)
+                    .build();
+
+            Album album2 = Album.builder()
+                    .artist("IU")
+                    .name("라일락")
+                    .price(65000)
+                    .stockQuantity(10)
+                    .build();
+
+            em.persist(album);
+            em.persist(album2);
+
+            OrderItem orderItem=OrderItem.createOrderItem(album,album.getPrice(),5);
+            OrderItem orderItem2=OrderItem.createOrderItem(album2,album2.getPrice(),2);
+            Order order = Order.createOrder(member,
+                    Delivery.builder().address(member.getAddress()).status(DeliveryStatus.READY).build(),
+                    orderItem, orderItem2);
+
+            em.persist(order);
+        }
+    }
+}
+
+

--- a/src/main/java/jpa/jpa_shop/service/IFS/OrderServiceIFS.java
+++ b/src/main/java/jpa/jpa_shop/service/IFS/OrderServiceIFS.java
@@ -12,4 +12,7 @@ public interface OrderServiceIFS {
     public void cancelOrder(Long orderId);
 
     public List<Order> SearchMemberNameAndOrderStatus(OrderSearchRequestDto requestDto);
+
+    List<Order> findWithMemberAndDelivery();
+
 }

--- a/src/main/java/jpa/jpa_shop/service/OrderService.java
+++ b/src/main/java/jpa/jpa_shop/service/OrderService.java
@@ -55,5 +55,10 @@ public class OrderService implements OrderServiceIFS {
         return orderRepository.findAll(requestDto);
     }
 
+    @Override
+    public List<Order> findWithMemberAndDelivery() {
+        return orderRepository.findWithMemberAndDelivery();
+    }
+
 
 }

--- a/src/main/java/jpa/jpa_shop/web/controller/API/OrderApiController.java
+++ b/src/main/java/jpa/jpa_shop/web/controller/API/OrderApiController.java
@@ -1,0 +1,34 @@
+package jpa.jpa_shop.web.controller.API;
+
+import jpa.jpa_shop.domain.orders.Order;
+import jpa.jpa_shop.domain.orders.Repository.OrderRepository;
+import jpa.jpa_shop.service.IFS.OrderServiceIFS;
+import jpa.jpa_shop.web.controller.dto.request.order.OrderSearchRequestDto;
+import jpa.jpa_shop.web.controller.dto.response.order.OrderResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/orders")
+@RestController
+public class OrderApiController {
+    private final OrderServiceIFS orderService;
+    @GetMapping("")
+    public List<OrderResponseDto> orderList()
+    {
+        return  orderService.SearchMemberNameAndOrderStatus(new OrderSearchRequestDto()).stream()
+                .map(Order::toDto).collect(Collectors.toList());
+    }
+
+
+    @GetMapping("/list")
+    public List<OrderResponseDto> orderList_Enhancement()
+    {
+        return orderService.findWithMemberAndDelivery().stream().map(Order::toDto).collect(Collectors.toList());
+    }
+}

--- a/src/main/java/jpa/jpa_shop/web/controller/dto/response/order/OrderResponseDto.java
+++ b/src/main/java/jpa/jpa_shop/web/controller/dto/response/order/OrderResponseDto.java
@@ -1,0 +1,33 @@
+package jpa.jpa_shop.web.controller.dto.response.order;
+
+import jpa.jpa_shop.domain.member.Address;
+import jpa.jpa_shop.domain.orders.OrderStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@NoArgsConstructor
+@Getter
+public class OrderResponseDto {
+    private Long id;
+    private String itemRepresentation;
+    private int totalPrice;
+    private OrderStatus orderStatus;
+    private String memberName;
+    private Address address;
+    private LocalDateTime orderDate;
+
+
+    @Builder
+    public OrderResponseDto(Long id, String itemRepresentation,int totalPrice,LocalDateTime orderDate, OrderStatus orderStatus, String memberName, Address address) {
+        this.id = id;
+        this.itemRepresentation=itemRepresentation;
+        this.totalPrice=totalPrice;
+        this.orderDate = orderDate;
+        this.orderStatus = orderStatus;
+        this.memberName = memberName;
+        this.address = address;
+    }
+}

--- a/src/main/resources/import.sql
+++ b/src/main/resources/import.sql
@@ -1,18 +1,18 @@
-insert into member (city, street, zipcode, name) values ('서울턱별시 강남구', '테헤란로', '12-1', '참깨');
-
-insert into member (city, street, zipcode, name) values ('인천 남덩구', '남덩로', '1032-12', '꾸꾸까까');
-
-insert into member (city, street, zipcode, name) values ('부싼 해운대구', '해운로', '554-33', '뭐라카노');
-
-
-insert into item (name, price, stock_quantity, author, isbn, dtype) values ('알고리즘 문제 해결 전략1', 33000, 15, '구종만', '123-123', 'B');
-
-insert into item (name, price, stock_quantity, artist, etc, dtype) values ('IU 미니 앨범', 28000, 10, 'IU', '작곡가,작사가: WhyWhale', 'A');
-
-insert into item (name, price, stock_quantity, actor, director, dtype) values ('트랜스포머<달의 어둠>', 10000, 30, '옵티머스프라임,범블비', '마이클 베이', 'M');
-
-insert into item (name, price, stock_quantity, artist, etc, dtype) values ('Rollin', 27000, 10, '브레이브걸스', '작곡가,작사가: 용감한 형제', 'A');
-
-insert into item (name, price, stock_quantity, author, isbn, dtype) values ('알고리즘 문제 해결 전략2', 33000, 15, '구종만', '123-1234', 'B');
-
-insert into item (name, price, stock_quantity, actor, director, dtype) values ('트랜스포머<사라진 시대>', 10000, 30, '옵티머스프라임,범블비', '마이클 베이', 'M');
+-- insert into member (city, street, zipcode, name) values ('서울턱별시 강남구', '테헤란로', '12-1', '참깨');
+--
+-- insert into member (city, street, zipcode, name) values ('인천 남덩구', '남덩로', '1032-12', '꾸꾸까까');
+--
+-- insert into member (city, street, zipcode, name) values ('부싼 해운대구', '해운로', '554-33', '뭐라카노');
+--
+--
+-- insert into item (name, price, stock_quantity, author, isbn, dtype) values ('알고리즘 문제 해결 전략1', 33000, 15, '구종만', '123-123', 'B');
+--
+-- insert into item (name, price, stock_quantity, artist, etc, dtype) values ('IU 미니 앨범', 28000, 10, 'IU', '작곡가,작사가: WhyWhale', 'A');
+--
+-- insert into item (name, price, stock_quantity, actor, director, dtype) values ('트랜스포머<달의 어둠>', 10000, 30, '옵티머스프라임,범블비', '마이클 베이', 'M');
+--
+-- insert into item (name, price, stock_quantity, artist, etc, dtype) values ('Rollin', 27000, 10, '브레이브걸스', '작곡가,작사가: 용감한 형제', 'A');
+--
+-- insert into item (name, price, stock_quantity, author, isbn, dtype) values ('알고리즘 문제 해결 전략2', 33000, 15, '구종만', '123-1234', 'B');
+--
+-- insert into item (name, price, stock_quantity, actor, director, dtype) values ('트랜스포머<사라진 시대>', 10000, 30, '옵티머스프라임,범블비', '마이클 베이', 'M');


### PR DESCRIPTION
 ※ **Entity 직접 노출시 오류**

1.jackson 라이브러리는 기본적으로 이 프록시 객체를 json으로 어떻게 생성해야 하는지 모른다. 그러므로 예외 발생한다. (정확히는 order는 member 와 그리고 Delivery 객체와 양방향 연관관계를 가지고 있다. Jackson은 객체를 계속 가지고 오는 무한 루프가 도는 현상이다. 그래서 일방적으로 양방향 관계의 객체를  Jackson이 무시 할 수 있게 필드명 위에 모두  @JsonIgnore 를 붙인다.)

2.lazy로 인한 문제 (Proxy Mode<ByteBuddyInterceptor>) 나는 이 프록시를 모 어떻게 할 수 없다고 나온다. 이 문제는 지연로딩의 문제인 경우 JsonLibrary한테 아무것도 뿌리려고 하지말라고 해야 한다. 그렇다고 Eager 로딩으로 한다면 성능의 문제를 야기할 수 있다. 되도록이면 지양하는 것이 대부분이였다. 그래서 2번의 해결방법은 lazy를 초기화 시키는 작업으로 해결할 수 있다.  즉 , 해당 order객체의 참조 객체의 안의 메소드를 사용하면 즉시 초기화가 된다.


## N+1의 문제(Lazy)
- 1번째 order query +N(2) (meber N + delivery N) 결국에는 1+2+2 쿼리문이 나간다.
 - 최악의 경우 :10건의 서로다른 사용자가 조회할때 총 1건 order에서 (영속성) 회원 10번 배송 10번.
- 항상 지연 로딩을 기본으로 하고, 성능 최적화가 필요한 경우에는 페치 조인(fetch join)을 사용함. 그러므로 같은 사용자가 물건을 두개 삿을 때 1+2+2 =5 번의 쿼리를 1번의 쿼리로 줄임.


