### PR TITLE
[#7]-조회 성능 이슈(QueryDto N+1 문제 해결.)

### DIFF
--- a/src/main/java/jpa/jpa_shop/Query/OrderQueryRepository.java
+++ b/src/main/java/jpa/jpa_shop/Query/OrderQueryRepository.java
@@ -8,24 +8,52 @@ import org.springframework.stereotype.Repository;
 
 import javax.persistence.EntityManager;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Repository
 public class OrderQueryRepository {
     private final EntityManager em;
-
-    public List<OrderQueryDetailDto> findDetailList(int offest, int limit) {
-        List<OrderQueryDetailDto> orders = findOrderDetails(offest, limit);
+    // N+1의 문제 발생. : 3개 (1+2<컬렉션>)
+    public List<OrderQueryDetailDto> findDetailList(int offset, int limit) {
+        List<OrderQueryDetailDto> orders = findOrderDetails(offset, limit);
         orders.forEach(orderQueryDto -> {
             List<OrderItemQueryDto> orderItems = findOrderItems(orderQueryDto.getOrderId());
             orderQueryDto.orderItemsAdd(orderItems);
         });
         return orders;
     }
+    // N+1의 문제 해결(In keyword) : 2개 (1+1<컬렉션>)
+    public List<OrderQueryDetailDto> ImproveFindDetailList(int offset, int limit)
+    {
+        List<OrderQueryDetailDto> orders=findOrderDetails(offset,limit);
+        List<Long> orderIds = orders.stream().map(OrderQueryDetailDto::getOrderId).collect(Collectors.toList());
+        List<OrderItemQueryDto> orderItems = OrderItemInQueryDtos(orderIds);
+
+        // map Stream
+        Map<Long, List<OrderItemQueryDto>> orderItemGrouping = memoryMap(orderItems);
+        orders.forEach(orderQueryDetailDto ->orderQueryDetailDto.orderItemsAdd(orderItemGrouping.get(orderQueryDetailDto.getOrderId())));
+        return orders;
+    }
+
+    private Map<Long, List<OrderItemQueryDto>> memoryMap(List<OrderItemQueryDto> orderItems) {
+        return orderItems.stream().collect(Collectors.groupingBy(OrderItemQueryDto::getOrderId));
+    }
+
+    private List<OrderItemQueryDto> OrderItemInQueryDtos(List<Long> orderIds) {
+        return em.createQuery(
+                "select  new jpa.jpa_shop.web.dto.response.orderItem.OrderItemQueryDto(oi.order.id,i.name,oi.orderPrice,oi.count)" +
+                        " from OrderItem oi" +
+                        " join oi.item i" +
+                        " where oi.order.id in :orderIds", OrderItemQueryDto.class)
+                .setParameter("orderIds", orderIds)
+                .getResultList();
+    }
 
     public List<OrderItemQueryDto> findOrderItems(Long orderId) {
         return em.createQuery(
-                "select  new jpa.jpa_shop.web.dto.response.orderItem.OrderItemQueryDto(i.name,oi.orderPrice,oi.count)" +
+                "select  new jpa.jpa_shop.web.dto.response.orderItem.OrderItemQueryDto(oi.order.id,i.name,oi.orderPrice,oi.count)" +
                         " from OrderItem oi" +
                         " join oi.item i" +
                         " where oi.order.id = : orderId"
@@ -35,24 +63,24 @@ public class OrderQueryRepository {
     }
 
 
-    public List<OrderQueryDto> findOrders(int offest, int limit) {
+    public List<OrderQueryDto> findOrders(int offset, int limit) {
         return em.createQuery(
                 "select new jpa.jpa_shop.web.dto.response.order.OrderQueryDto(o.id,m.name,o.orderDate,o.status, d.address)" +
                         " from Order o" +
                         " join o.member m" +
                         " join o.delivery d", OrderQueryDto.class)
-                .setFirstResult(offest)
+                .setFirstResult(offset)
                 .setMaxResults(limit)
                 .getResultList();
     }
 
-    private List<OrderQueryDetailDto> findOrderDetails(int offest, int limit) {
+    private List<OrderQueryDetailDto> findOrderDetails(int offset, int limit) {
         return em.createQuery(
                 "select new jpa.jpa_shop.web.dto.response.order.OrderQueryDetailDto(o.id,m.name,o.orderDate,o.status, d.address)" +
                         " from Order o" +
                         " join o.member m" +
                         " join o.delivery d", OrderQueryDetailDto.class)
-                .setFirstResult(offest)
+                .setFirstResult(offset)
                 .setMaxResults(limit)
                 .getResultList();
     }

--- a/src/main/java/jpa/jpa_shop/web/controller/API/OrderApiController.java
+++ b/src/main/java/jpa/jpa_shop/web/controller/API/OrderApiController.java
@@ -66,7 +66,7 @@ public class OrderApiController {
     public List<OrderQueryDetailDto> orderQueryDetailDtos(@RequestParam(value = "offset",defaultValue = "0" ,required = false) int offset,
                                                           @RequestParam(value = "limit",defaultValue = "10", required = false) int limit)
     {
-        return orderQueryRepository.findDetailList(offset,limit);
+        return orderQueryRepository.ImproveFindDetailList(offset,limit);
     }
 
     @PostMapping("")

--- a/src/main/java/jpa/jpa_shop/web/dto/response/order/OrderQueryDetailDto.java
+++ b/src/main/java/jpa/jpa_shop/web/dto/response/order/OrderQueryDetailDto.java
@@ -19,6 +19,8 @@ public class OrderQueryDetailDto {
     private Address address;
     private List<OrderItemQueryDto> orderItems;
 
+
+
     public OrderQueryDetailDto(Long orderId, String name, LocalDateTime orderDate, OrderStatus orderStatus, Address address) {
         this.orderId = orderId;
         this.name = name;

--- a/src/main/java/jpa/jpa_shop/web/dto/response/orderItem/OrderItemQueryDto.java
+++ b/src/main/java/jpa/jpa_shop/web/dto/response/orderItem/OrderItemQueryDto.java
@@ -1,14 +1,19 @@
 package jpa.jpa_shop.web.dto.response.orderItem;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import lombok.Getter;
 
 @Getter
 public class OrderItemQueryDto {
+    @JsonIgnore
+    private Long orderId;
+
     private String itemName;
     private int orderPrice;
     private int count;
 
-    public OrderItemQueryDto(String itemName, int orderPrice, int count) {
+    public OrderItemQueryDto(Long orderId,String itemName, int orderPrice, int count) {
+        this.orderId=orderId;
         this.itemName = itemName;
         this.orderPrice = orderPrice;
         this.count = count;


### PR DESCRIPTION
- queryDto 조회시 N+1 문제 발견.

## 🛠 code

```javascript
public List<OrderQueryDetailDto> findDetailList(int offset, int limit) {
        List<OrderQueryDetailDto> orders = findOrderDetails(offset, limit);
        orders.forEach(orderQueryDto -> {
            List<OrderItemQueryDto> orderItems = findOrderItems(orderQueryDto.getOrderId());
            orderQueryDto.orderItemsAdd(orderItems);
        });
        return orders;
    }
``` 
**findOrderDetails 의 메소드를 호출하면 해당 queryDto를 가져오는데 xToOne관계인 객체들만 조인하여 가져온다. 그리고 나서 스트림을 통해 가공을 하는데 findOrderItems라는 메소드를 호출하여 각 사용자별 where id= * 을 하여 쿼리가 실행된다. 즉 사용자 명수마다 order_item ,item이 조인한 쿼리가 출력된다.**



## 💡 수정 결과

- N+1의 문제를 해결하고 쿼리문이 딱 2번이 발생하도록 개선하였다.

```javascript
 public List<OrderQueryDetailDto> ImproveFindDetailList(int offset, int limit)
    {
        List<OrderQueryDetailDto> orders=findOrderDetails(offset,limit);
        List<Long> orderIds = orders.stream().map(OrderQueryDetailDto::getOrderId).collect(Collectors.toList());
        List<OrderItemQueryDto> orderItems = OrderItemInQueryDtos(orderIds);

        // map Stream
        Map<Long, List<OrderItemQueryDto>> orderItemGrouping = memoryMap(orderItems);
        orders.forEach(orderQueryDetailDto ->orderQueryDetailDto.orderItemsAdd(orderItemGrouping.get(orderQueryDetailDto.getOrderId())));
        return orders;
    }

    private Map<Long, List<OrderItemQueryDto>> memoryMap(List<OrderItemQueryDto> orderItems) {
        return orderItems.stream().collect(Collectors.groupingBy(OrderItemQueryDto::getOrderId));
    }

    private List<OrderItemQueryDto> OrderItemInQueryDtos(List<Long> orderIds) {
        return em.createQuery(
                "select  new jpa.jpa_shop.web.dto.response.orderItem.OrderItemQueryDto(oi.order.id,i.name,oi.orderPrice,oi.count)" +
                        " from OrderItem oi" +
                        " join oi.item i" +
                        " where oi.order.id in :orderIds", OrderItemQueryDto.class)
                .setParameter("orderIds", orderIds)
                .getResultList();
    }
```

**우선 xToOne관계를 가진 객체들은 Lazy이므로 join을 해서 가져온다. 그리고 해당 가져온 객체를 가지고 id값많을 따로 추출한다. 그리고 orderItem에 '=' -> 'in'으로 교체 후 아까 id값만을 추출한 리스트를 해당 인자에 넣어준다. 그리고 스트림의 groupingBy를 사용하였다. 왜냐하면 해당 키값 을 orderId로 하고 해당 관련된 아이템들의 묶음을 값으로 가질 수 있게 했다. 이로서 데이터를 가져오는 시간에서 O(1)로 접근한다. 그 후에 바로 맵을 이용하여  가장 처음에 가져온 객체에 스트림을 사용하여 order와 N의 관계의 컬렉션을 넣어준다. 이로써 기존에는 하나씩 사용자 별로 조건을 다르게 명시하여 사용자명수에 따라 쿼리문이 더 나가는 문제를 in ('*', '*') 을 통해 한번에 가져오고 각 컬렉션들을 한번에 넣을 수 있도록 스트림 맵으로 가공한 후에 한번에 넣어주어 해결했다.**


